### PR TITLE
fix: invalid invite for discord town hall

### DIFF
--- a/wiki/resources/official-servers.md
+++ b/wiki/resources/official-servers.md
@@ -17,11 +17,11 @@ __Link:__ [Discord Developers](https://discord.gg/discord-developers)
 
 @gg/discord-developers
 
-## **Discord Townhall** 
+## **Discord Town Hall** 
 > __Description:__ An official general chatting server for people who love Discord.  Find the latest news, events, and a community you love!   <br/>
-__Link:__ [Discord Townhall](https://discord.gg/discord-townhall)
+__Link:__ [Discord Town Hall](https://discord.gg/snowsgiving)
 
-@gg/discord-townhall
+@gg/snowsgiving
 
 ## **Discord Games Lab** 
 > __Description:__ The official server for Discord's Games Lab. Come play Poker Night, Chess, or Watch Together with your friends!   <br/>


### PR DESCRIPTION
Discord Town Hall's current vanity URL is set to discord.gg/snowsgiving, so discord.gg/discord-townhall is invalid.
Also changed Discord Townhall to Discord Town Hall to match the current server name.

` - ` Shade.#0975 (560484031838552064)