### PR TITLE
fix: invite embed not showing up on website

### DIFF
--- a/wiki/resources/official-servers.md
+++ b/wiki/resources/official-servers.md
@@ -21,7 +21,7 @@ __Link:__ [Discord Developers](https://discord.gg/discord-developers)
 > __Description:__ An official general chatting server for people who love Discord.  Find the latest news, events, and a community you love!   <br/>
 __Link:__ [Discord Town Hall](https://discord.gg/discord-townhall)
 
-@gg/snowsgiving
+@gg/discord-townhall
 
 ## **Discord Games Lab** 
 > __Description:__ The official server for Discord's Games Lab. Come play Poker Night, Chess, or Watch Together with your friends!   <br/>


### PR DESCRIPTION
the invite embed still has the invite `@gg/snowsgiving` which shows up as a different server on the website, this pr fixes that.