### PR TITLE
Add misspelled Github url

### DIFF
--- a/wiki/resources/fun-links.md
+++ b/wiki/resources/fun-links.md
@@ -75,4 +75,5 @@ https://tikolu.net/font-changer/ | font changer  <br/>
 https://tikolu.net/time/ | accurate time  <br/>
 https://yonilerner.wtf/ | wtf  <br/>
 http://needsmorejpeg.com/ |  need more jpeg  <br/>
-https://trashttpandas.ragnarok.workers.dev/ | http racoons
+https://trashttpandas.ragnarok.workers.dev/ | http racoons  <br/>
+https://guthib.com | POV: You just woke up and wanted to open Github


### PR DESCRIPTION
# New Resource PR Template

just as the name says

**You spelled it wrong.**

## Name of Resource:

Guthib

## Description of Resource:

A URL for people who tried to open Github but misplaced the `u` and `i`

## A Link to the Resource:

https://guthib.com

## Discord ID(s) of the Creator(s):

(Unknown)