### PR TITLE
Add credits for Unofficial Discord API Docs

### DIFF
--- a/wiki/resources/bots/info.md
+++ b/wiki/resources/bots/info.md
@@ -8,7 +8,8 @@ description: Bot informations and lists
 
 ## **Unofficial Discord API Docs**
 > __Description:__ Unofficial documentation for Undocumented Discord APIs. Also contains an outline of Discord's infrastructure.  <br/>
-__Link:__ [Unofficial Discord API Docs](https://luna.gitlab.io/discord-unofficial-docs/)
+__Link:__ [Unofficial Discord API Docs](https://luna.gitlab.io/discord-unofficial-docs/)  <br/>
+__Credit:__ @github:luna
 
 ## **Largest Discord Bots**
 > __Description:__ An easy-to-read list of the top 25 Discord bots by server count.   <br/>


### PR DESCRIPTION
Add credits for Unofficial Discord API Docs, although this is her github account and not the gitlab one