### PR TITLE
Add DCreators

### DIFF
--- a/wiki/resources/unofficial-servers.md
+++ b/wiki/resources/unofficial-servers.md
@@ -87,3 +87,11 @@ description: Unofficial servers related to discord.
 **Credit:** The Programmers Hangout team (owned by @335628039302021121)
 
 @gg/programming
+
+## **DCreators**
+
+> **Description:** Private community to mainly connect with verified bot and library developers  <br/>
+**Link:** [DCreators (Access by developing on a verified bot/library)](https://discord.gg/JxTyeKpcaw)   <br/>
+**Credit:** DCreator team (owned by @691288534375596062)
+
+@gg/JxTyeKpcaw


### PR DESCRIPTION
I am a member on a server called "DCreators", which is a private community of verified bot developers and library developers (Core Contributors) (pycord, discordeno ....)
This Server is fortunately more open and you won't need a vouch to join that server.
I am not sure, if I am allowed to suggest this, but I linked the owners id, so you can hit him up.

Would love to see it on your webpage ^^

# New Resource PR Template

## Name of Resource: DCreators

## Description of Resource:
Private community to mainly connect with verified bot and library developers.

## A Link to the Resource: https://discord.gg/JxTyeKpcaw

## Discord ID(s) of the Creator(s): 691288534375596062

