### PR TITLE
Fix "Link(s)" inconsistency

### DIFF
--- a/wiki/resources/official-files.md
+++ b/wiki/resources/official-files.md
@@ -11,19 +11,19 @@ description: Official files from Discord.
 ### **Server Audits**
 
 > **Description:** A Discord presentation and audio regarding server audits.  <br/>
-**Links:** <br/>
+**Link(s):** <br/>
 [Slides Presentation](https://docs.google.com/presentation/d/18QQyl0WhTOdYt0F0mBPQf2AusBPF7HqP8e39zjEwKsc/edit#slide=id.g130c86c984d_0_12)  <br/>
 [Audio Presentation](https://cdn.discordapp.com/attachments/960960145800704030/982392876254232667/DAC_AuditingYourServer_ExperimentalContent.mp3)
 
 ### **All-Things Accessibility**
 > **Description:** A Discord interview (audio and transcript) about accessibility with a Discord employee from the accessbility team.  <br/>
 **Link(s):** <br/>
-[Audio](https://dis.gd/RadioDiscord_Accessibility )  <br/>
+[Audio](https://dis.gd/RadioDiscord_Accessibility)  <br/>
 [Transcript](https://dis.gd/RadioDiscordAccessibilityTranscript)
 
 ### **Discussing The Forums Feature**
 > **Description:** The Discord community team talks about a new feature in testing: forums.  <br/>
-**Links:** <br/>
+**Link(s):** <br/>
 [Audio](https://dis.gd/Radio-Discord-Forums-Beta)  <br/>
 [Transcript](https://dis.gd/Radio-Discord-Forums-Beta-Transcript)
 


### PR DESCRIPTION
i chose "Link(s)" over "Links", because "Link(s)" is used more (website wise)

also removes a useless space btw