### PR TITLE
Remove Report Form from Official Forms

### DIFF
--- a/wiki/resources/official-forms.md
+++ b/wiki/resources/official-forms.md
@@ -6,11 +6,6 @@ description: Official forms from Discord.
 
 # Official Forms
 
-## Report Form
-
-> **Description:** Report an issue to Discord’s Trust and Safety team.   <br/>
-**Link:** [Discord Report Form](https://dis.gd/report)
-
 ## Support Form
 
 > **Description:** Need help? Submit a request to the Discord team.   <br/>


### PR DESCRIPTION
You can no longer use that form to report. All reporting is done in-app.