### PR TITLE
Update phishing.md

### DIFF
--- a/wiki/resources/tools/phishing.md
+++ b/wiki/resources/tools/phishing.md
@@ -65,7 +65,7 @@ description: Phishing and Security tools
 [Blacklisted Domains](https://api.hyperphish.com/gimme-domains) <br/>
 [Malware & URL Scanner](https://chrome.google.com/webstore/detail/malware-url-scanner/ianpniapgjchiheejeipopldaanbjicd) <br/>
 [ipqualityscore](https://www.ipqualityscore.com/threat-feeds/malicious-url-scanner)  <br/>
-[Azrael Phish API](https://phish.azrael.gg/) (credit: @641795527444529152)  <br/>
+[Uplink](https://uplink.digitaldimensions.cc) (credit: @641795527444529152)  <br/>
 [Walshy's API](https://bad-domains.walshy.dev/)
 
 ## Phisherman


### PR DESCRIPTION
This PR updates the existing "Azrael Phish API" to be the new "Uplink" API. "Azrael Phish" has been deprecated and is being replaced by "Uplink".
